### PR TITLE
Add Tuple to typing imports in trainer.py

### DIFF
--- a/olfactory_transformer/training/trainer.py
+++ b/olfactory_transformer/training/trainer.py
@@ -1,6 +1,6 @@
 """Training infrastructure for olfactory transformer models."""
 
-from typing import Dict, List, Optional, Any, Union, Callable
+from typing import Dict, List, Optional, Any, Union, Callable, Tuple
 import logging
 import time
 from pathlib import Path


### PR DESCRIPTION
## Summary
- Updated the import statement in `trainer.py` to include `Tuple` from the `typing` module.

## Changes

### Code Update
- Modified the import line in `olfactory_transformer/training/trainer.py` to add `Tuple` alongside existing imports from `typing`.

## Test plan
- No functional changes; no additional tests required.
- Ensure existing training scripts run without import errors.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/548c3c2e-4627-4c8f-a36f-7396057258d1

## Summary by Sourcery

Bug Fixes:
- Include the missing Tuple import from the typing module in olfactory_transformer/training/trainer.py.